### PR TITLE
Separates data arrays into contenttype- and fielddefinitionobjects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /vendor
 /composer.lock
 /var
-/tests/EzPlatform/*/var
+/tests/Transfer/EzPlatform/*/var

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Notice
 
 This extension is still under development. There is currently no stable release.
 
+It will stay that way until as stable 6.x release of [ezpublish-kernel](https://github.com/ezsystems/ezpublish-kernel/releases) is tagged.
+
 Installation
 ------------
 
@@ -16,3 +18,30 @@ Install the latest version with:
     $ composer require transfer/ezplatform 
 
 This requires [Composer](https://getcomposer.org/download/) to be installed globally in your system.
+
+
+Usage
+------------
+
+Docs is coming..
+
+Contribution
+------------
+
+Any contribution is very welcome, especially feature requests at this point.
+
+Todo
+------------
+
+Handling the following type of data:
+
+- [x] Content and Locations
+- [x] ContentType and FieldTypes
+- [ ] Languages
+- [ ] Trash
+- [ ] Sections
+- [ ] User
+- [ ] UrlAlias and UrlWildcards
+- [ ] Documentation
+
+All of these might not be implemented before the first stable tagged release.

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php": ">=5.4.4",
-        "transfer/transfer": "~1.0.0"
+        "transfer/transfer": "~1.0.0",
+        "ezsystems/ezpublish-kernel": "dev-master"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.7",
-        "ezsystems/ezpublish-kernel": "dev-master"
+        "phpunit/phpunit": "^4.7"
     },
     "autoload": {
         "psr-4": { "Transfer\\EzPlatform\\": "src/Transfer/EzPlatform/" }

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "type": "transfer-extension",
     "description": "eZ Platform extension for Transfer",
     "keywords": ["transfer", "ezpublish", "ezplatform"],
+    "minimun-stability": "dev",
     "license": "MIT",
     "author": [
         {
@@ -16,11 +17,11 @@
     ],
     "require": {
         "php": ">=5.4.4",
-        "transfer/transfer": "~1.0",
-        "ezsystems/ezpublish-kernel": "dev-master"
+        "transfer/transfer": "~1.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.7"
+        "phpunit/phpunit": "^4.7",
+        "ezsystems/ezpublish-kernel": "dev-master"
     },
     "autoload": {
         "psr-4": { "Transfer\\EzPlatform\\": "src/Transfer/EzPlatform/" }

--- a/src/Transfer/EzPlatform/Data/ContentTypeObject.php
+++ b/src/Transfer/EzPlatform/Data/ContentTypeObject.php
@@ -10,6 +10,7 @@
 namespace Transfer\EzPlatform\Data;
 
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeCreateStruct;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeUpdateStruct;
 
 /**
@@ -244,9 +245,27 @@ class ContentTypeObject
     }
 
     /**
+     * @param ContentTypeCreateStruct $contentTypeCreateStruct
+     */
+    public function fillContentTypeCreateStruct(ContentTypeCreateStruct &$contentTypeCreateStruct)
+    {
+        $contentTypeCreateStruct->names = $this->getNames();
+        $contentTypeCreateStruct->remoteId = sha1(microtime());
+        $contentTypeCreateStruct->isContainer = $this->isContainer;
+        $contentTypeCreateStruct->mainLanguageCode = $this->mainLanguageCode;
+        $contentTypeCreateStruct->nameSchema = $this->nameSchema;
+        $contentTypeCreateStruct->urlAliasSchema = $this->urlAliasSchema;
+        $contentTypeCreateStruct->descriptions = $this->getDescriptions();
+        $contentTypeCreateStruct->isContainer = $this->isContainer;
+        $contentTypeCreateStruct->defaultAlwaysAvailable = $this->defaultAlwaysAvailable;
+        $contentTypeCreateStruct->defaultSortField = $this->defaultSortField;
+        $contentTypeCreateStruct->defaultSortOrder = $this->defaultSortOrder;
+    }
+
+    /**
      * @param ContentTypeUpdateStruct $contentTypeUpdateStruct
      */
-    public function fillContentTypeStruct(&$contentTypeUpdateStruct)
+    public function fillContentTypeUpdateStruct(ContentTypeUpdateStruct &$contentTypeUpdateStruct)
     {
         $contentTypeUpdateStruct->names = $this->getNames();
         $contentTypeUpdateStruct->descriptions = $this->getDescriptions();

--- a/src/Transfer/EzPlatform/Data/ContentTypeObject.php
+++ b/src/Transfer/EzPlatform/Data/ContentTypeObject.php
@@ -9,11 +9,253 @@
 
 namespace Transfer\EzPlatform\Data;
 
-use Transfer\Data\ValueObject;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeUpdateStruct;
 
 /**
  * Content type object.
  */
-class ContentTypeObject extends ValueObject
+class ContentTypeObject
 {
+    /**
+     * @var string
+     */
+    protected $identifier;
+
+    /**
+     * @var string
+     */
+    public $mainLanguageCode = 'eng-GB';
+
+    /**
+     * @var array
+     */
+    protected $contentTypeGroups = array('Content');
+
+    /**
+     * @var array
+     */
+    protected $names = array();
+
+    /**
+     * @var array
+     */
+    protected $descriptions = array();
+
+    /**
+     * @var string
+     */
+    public $nameSchema;
+
+    /**
+     * @var string
+     */
+    public $urlAliasSchema;
+
+    /**
+     * @var bool
+     */
+    public $isContainer = true;
+
+    /**
+     * @var bool
+     */
+    public $defaultAlwaysAvailable = true;
+
+    /**
+     * Valid values are found at {@link Location::SORT_FIELD_*}.
+     *
+     * @var int
+     */
+    public $defaultSortField = Location::SORT_FIELD_NAME;
+
+    /**
+     * Valid values are found at {@link Location::SORT_ORDER_*}.
+     *
+     * @var int
+     */
+    public $defaultSortOrder = Location::SORT_ORDER_ASC;
+
+    /**
+     * @var FieldDefinitionObject[]
+     */
+    protected $fieldDefinitions = array();
+
+    /**
+     * ContentTypeObject constructor.
+     *
+     * @param string $identifier
+     */
+    public function __construct($identifier)
+    {
+        $this->identifier = $identifier;
+        $this->names = array($this->mainLanguageCode => $this->identifierToReadable($identifier));
+    }
+
+    /**
+     * @return bool
+     */
+    public function isValid()
+    {
+        return strlen(trim($this->identifier)) > 0 && count($this->getFieldDefinitions()) > 0;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMainGroupIdentifier()
+    {
+        return $this->contentTypeGroups[0];
+    }
+
+    /**
+     * Converts an identifier to one or more words
+     *  'name' -> 'Name'
+     *  'short_description' -> 'Short Description'.
+     *
+     * @param string $identifier
+     *
+     * @return string
+     */
+    protected function identifierToReadable($identifier)
+    {
+        return ucwords(str_replace('_', ' ', $identifier));
+    }
+
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * @param string $contentTypeGroup
+     */
+    public function addContentTypeGroup($contentTypeGroup)
+    {
+        $this->contentTypeGroups[] = $contentTypeGroup;
+    }
+
+    /**
+     * @param array $contentTypeGroups
+     */
+    public function setContentTypeGroups(array $contentTypeGroups)
+    {
+        $this->contentTypeGroups = $contentTypeGroups;
+    }
+
+    /**
+     * @return array
+     */
+    public function getContentTypeGroups()
+    {
+        return $this->contentTypeGroups;
+    }
+
+    /**
+     * @param string $name
+     * @param string $languageCode
+     */
+    public function addName($name, $languageCode = null)
+    {
+        $languageCode = $languageCode !== null ? $languageCode : $this->mainLanguageCode;
+        $this->names[$languageCode] = $name;
+    }
+
+    /**
+     * @param array $names array('eng-GB'=>'My Name')
+     */
+    public function setNames(array $names)
+    {
+        $this->names = $names;
+    }
+
+    /**
+     * @return array
+     */
+    public function getNames()
+    {
+        return $this->names;
+    }
+
+    /**
+     * @param string $description
+     * @param string $languageCode
+     */
+    public function addDescription($description, $languageCode = null)
+    {
+        $languageCode = $languageCode !== null ? $languageCode : $this->mainLanguageCode;
+        $this->descriptions[$languageCode] = $description;
+    }
+
+    /**
+     * @param array $descriptions array('eng-GB' => 'My description')
+     */
+    public function setDescriptions(array $descriptions)
+    {
+        $this->descriptions = $descriptions;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDescriptions()
+    {
+        return $this->descriptions;
+    }
+
+    /**
+     * @param FieldDefinitionObject $field
+     */
+    public function addFieldDefinition(FieldDefinitionObject $field)
+    {
+        if (count($this->fieldDefinitions) > 0) {
+            foreach ($this->fieldDefinitions as $index => $fieldDefinition) {
+                if ($fieldDefinition->getIdentifier() == $field->getIdentifier()) {
+                    $this->fieldDefinitions[$index] = $field;
+
+                    return;
+                }
+            }
+        } else {
+            if (empty($this->nameSchema)) {
+                $this->nameSchema = sprintf('<%s>', $field->getIdentifier());
+            }
+            if (empty($this->urlAliasSchema)) {
+                $this->urlAliasSchema = sprintf('<%s>', $field->getIdentifier());
+            }
+        }
+        $this->fieldDefinitions[] = $field;
+    }
+
+    /**
+     * @param FieldDefinitionObject[] $fields
+     */
+    public function setFieldDefinitions(array $fields)
+    {
+        $this->fieldDefinitions = $fields;
+    }
+
+    /**
+     * @return FieldDefinitionObject[]
+     */
+    public function getFieldDefinitions()
+    {
+        return $this->fieldDefinitions;
+    }
+
+    /**
+     * @param ContentTypeUpdateStruct $contentTypeUpdateStruct
+     */
+    public function fillContentTypeStruct(&$contentTypeUpdateStruct)
+    {
+        $contentTypeUpdateStruct->names = $this->getNames();
+        $contentTypeUpdateStruct->descriptions = $this->getDescriptions();
+        $contentTypeUpdateStruct->mainLanguageCode = $this->mainLanguageCode;
+        $contentTypeUpdateStruct->nameSchema = $this->nameSchema;
+        $contentTypeUpdateStruct->urlAliasSchema = $this->urlAliasSchema;
+        $contentTypeUpdateStruct->isContainer = $this->isContainer;
+        $contentTypeUpdateStruct->defaultAlwaysAvailable = $this->defaultAlwaysAvailable;
+        $contentTypeUpdateStruct->defaultSortField = $this->defaultSortField;
+        $contentTypeUpdateStruct->defaultSortOrder = $this->defaultSortOrder;
+    }
 }

--- a/src/Transfer/EzPlatform/Data/FieldDefinitionObject.php
+++ b/src/Transfer/EzPlatform/Data/FieldDefinitionObject.php
@@ -157,7 +157,7 @@ class FieldDefinitionObject
     /**
      * @param FieldDefinitionCreateStruct $fieldDefinitionCreateStruct
      */
-    public function dsa(&$fieldDefinitionCreateStruct)
+    public function fillFieldDefinitionCreateStruct(FieldDefinitionCreateStruct &$fieldDefinitionCreateStruct)
     {
         $fieldDefinitionCreateStruct->names = $this->getNames();
         $fieldDefinitionCreateStruct->descriptions = $this->getDescriptions();
@@ -172,7 +172,7 @@ class FieldDefinitionObject
     /**
      * @param FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct
      */
-    public function fillFieldDefinitionUpdateStruct(&$fieldDefinitionUpdateStruct)
+    public function fillFieldDefinitionUpdateStruct(FieldDefinitionUpdateStruct &$fieldDefinitionUpdateStruct)
     {
         $fieldDefinitionUpdateStruct->names = $this->getNames();
         $fieldDefinitionUpdateStruct->descriptions = $this->getDescriptions();

--- a/src/Transfer/EzPlatform/Data/FieldDefinitionObject.php
+++ b/src/Transfer/EzPlatform/Data/FieldDefinitionObject.php
@@ -1,0 +1,186 @@
+<?php
+
+/*
+ * This file is part of Transfer.
+ *
+ * For the full copyright and license information, please view the LICENSE file located
+ * in the root directory.
+ */
+
+namespace Transfer\EzPlatform\Data;
+
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionUpdateStruct;
+
+/**
+ * Content type object.
+ */
+class FieldDefinitionObject
+{
+    /**
+     * @var string
+     */
+    protected $identifier;
+
+    /**
+     * @var string
+     */
+    public $type = 'ezstring';
+
+    /**
+     * @var string
+     */
+    public $fieldGroup = 'content';
+
+    /**
+     * @var int
+     */
+    public $position;
+
+    /**
+     * @var bool
+     */
+    public $isRequired = false;
+
+    /**
+     * @var bool
+     */
+    public $isTranslatable = true;
+
+    /**
+     * @var bool
+     */
+    public $isSearchable = true;
+
+    /**
+     * @var bool
+     */
+    public $isInfoCollector = false;
+
+    /**
+     * @var string
+     */
+    public $defaultValue;
+
+    /**
+     * @var array
+     */
+    protected $names = array();
+
+    /**
+     * @var array
+     */
+    protected $descriptions = array();
+
+    /**
+     * FieldDefinitionObject constructor.
+     *
+     * @param string $identifier
+     */
+    public function __construct($identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Converts a string to one or more words
+     *  'name' -> 'Name'
+     *  'short_description' -> 'Short Description'.
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    protected function stringToReadable($string)
+    {
+        return ucwords(str_replace('_', ' ', $string));
+    }
+
+    /**
+     * @param string $description
+     * @param string $languageCode
+     */
+    public function addDescription($description, $languageCode = 'eng-GB')
+    {
+        $this->descriptions[$languageCode] = $description;
+    }
+
+    /**
+     * @param array $descriptions
+     */
+    public function setDescriptions(array $descriptions)
+    {
+        $this->descriptions = $descriptions;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDescriptions()
+    {
+        return $this->descriptions;
+    }
+
+    /**
+     * @param string $name
+     * @param string $languageCode
+     */
+    public function addName($name, $languageCode = 'eng-GB')
+    {
+        $this->names[$languageCode] = $name;
+    }
+
+    /**
+     * @param array $names
+     */
+    public function setNames(array $names)
+    {
+        $this->names = $names;
+    }
+
+    /**
+     * @return array
+     */
+    public function getNames()
+    {
+        return $this->names;
+    }
+
+    /**
+     * @param FieldDefinitionCreateStruct $fieldDefinitionCreateStruct
+     */
+    public function dsa(&$fieldDefinitionCreateStruct)
+    {
+        $fieldDefinitionCreateStruct->names = $this->getNames();
+        $fieldDefinitionCreateStruct->descriptions = $this->getDescriptions();
+        $fieldDefinitionCreateStruct->fieldGroup = $this->fieldGroup;
+        $fieldDefinitionCreateStruct->position = $this->position;
+        $fieldDefinitionCreateStruct->isTranslatable = $this->isTranslatable;
+        $fieldDefinitionCreateStruct->isRequired = $this->isRequired;
+        $fieldDefinitionCreateStruct->isInfoCollector = $this->isInfoCollector;
+        $fieldDefinitionCreateStruct->isSearchable = $this->isSearchable;
+    }
+
+    /**
+     * @param FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct
+     */
+    public function fillFieldDefinitionUpdateStruct(&$fieldDefinitionUpdateStruct)
+    {
+        $fieldDefinitionUpdateStruct->names = $this->getNames();
+        $fieldDefinitionUpdateStruct->descriptions = $this->getDescriptions();
+        $fieldDefinitionUpdateStruct->fieldGroup = $this->fieldGroup;
+        $fieldDefinitionUpdateStruct->position = $this->position;
+        $fieldDefinitionUpdateStruct->isTranslatable = $this->isTranslatable;
+        $fieldDefinitionUpdateStruct->isRequired = $this->isRequired;
+        $fieldDefinitionUpdateStruct->isInfoCollector = $this->isInfoCollector;
+        $fieldDefinitionUpdateStruct->isSearchable = $this->isSearchable;
+    }
+}

--- a/src/Transfer/EzPlatform/Exception/InvalidDataStructureException.php
+++ b/src/Transfer/EzPlatform/Exception/InvalidDataStructureException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Transfer\EzPlatform\Exception;
+
+/**
+ * Exception class for cases when object data is missing required keys/values.
+ */
+class InvalidDataStructureException extends \Exception
+{
+}

--- a/src/Transfer/EzPlatform/Repository/Manager/ContentManager.php
+++ b/src/Transfer/EzPlatform/Repository/Manager/ContentManager.php
@@ -93,9 +93,8 @@ class ContentManager implements LoggerAwareInterface, CreatorInterface, UpdaterI
     {
         try {
             $content = $this->contentService->loadContentByRemoteId($remoteId);
-        }
-        catch (\Exception $e) {
-            return null;
+        } catch (\Exception $e) {
+            return;
         }
 
         $object = new ContentObject($content->fields);
@@ -133,7 +132,7 @@ class ContentManager implements LoggerAwareInterface, CreatorInterface, UpdaterI
         $this->created[] = $object;
 
         // @TODO Return ContentObject
-        return null;
+        return;
     }
 
     /**
@@ -159,7 +158,7 @@ class ContentManager implements LoggerAwareInterface, CreatorInterface, UpdaterI
         $object->setContentInfo($content->contentInfo);
 
         // @TODO Return ContentObject
-        return null;
+        return;
     }
 
     /**
@@ -241,7 +240,7 @@ class ContentManager implements LoggerAwareInterface, CreatorInterface, UpdaterI
         $object->setMainLocationId($location->id);
 
         if ($object->getContentInfo() == null) {
-            return null;
+            return;
         }
 
         return $this->contentService->updateContentMetadata($object->getContentInfo(), $contentMetadataUpdateStruct);

--- a/src/Transfer/EzPlatform/Repository/Manager/ContentTypeManager.php
+++ b/src/Transfer/EzPlatform/Repository/Manager/ContentTypeManager.php
@@ -97,30 +97,13 @@ class ContentTypeManager implements LoggerAwareInterface
         }
 
         $contentTypeCreateStruct = $this->contentTypeService->newContentTypeCreateStruct($object->getIdentifier());
-        $contentTypeCreateStruct->names = $object->getNames();
-        $contentTypeCreateStruct->remoteId = sha1(microtime());
-        $contentTypeCreateStruct->isContainer = $object->isContainer;
-        $contentTypeCreateStruct->mainLanguageCode = $object->mainLanguageCode;
-        $contentTypeCreateStruct->nameSchema = $object->nameSchema;
-        $contentTypeCreateStruct->urlAliasSchema = $object->urlAliasSchema;
-        $contentTypeCreateStruct->descriptions = $object->getDescriptions();
-        $contentTypeCreateStruct->isContainer = $object->isContainer;
-        $contentTypeCreateStruct->defaultAlwaysAvailable = $object->defaultAlwaysAvailable;
-        $contentTypeCreateStruct->defaultSortField = $object->defaultSortField;
-        $contentTypeCreateStruct->defaultSortOrder = $object->defaultSortOrder;
+        $object->fillContentTypeCreateStruct($contentTypeCreateStruct);
 
         foreach ($object->getFieldDefinitions() as $field) {
             /* @var FieldDefinitionObject $field */
-            $titleFieldCreateStruct = $this->contentTypeService->newFieldDefinitionCreateStruct($field->getIdentifier(), $field->type);
-            $titleFieldCreateStruct->names = $field->getNames();
-            $titleFieldCreateStruct->descriptions = $field->getDescriptions();
-            $titleFieldCreateStruct->fieldGroup = $field->fieldGroup;
-            $titleFieldCreateStruct->position = $field->position;
-            $titleFieldCreateStruct->isTranslatable = $field->isTranslatable;
-            $titleFieldCreateStruct->isRequired = $field->isRequired;
-            $titleFieldCreateStruct->isSearchable = $field->isSearchable;
-            $titleFieldCreateStruct->isInfoCollector = $field->isInfoCollector;
-            $contentTypeCreateStruct->addFieldDefinition($titleFieldCreateStruct);
+            $fieldCreateStruct = $this->contentTypeService->newFieldDefinitionCreateStruct($field->getIdentifier(), $field->type);
+            $field->fillFieldDefinitionCreateStruct($fieldCreateStruct);
+            $contentTypeCreateStruct->addFieldDefinition($fieldCreateStruct);
         }
 
         $contentTypeGroup = $this->contentTypeService->loadContentTypeGroupByIdentifier($object->getMainGroupIdentifier());
@@ -194,7 +177,7 @@ class ContentTypeManager implements LoggerAwareInterface
         }
 
         $contentTypeUpdateStruct = $this->contentTypeService->newContentTypeUpdateStruct();
-        $object->fillContentTypeStruct($contentTypeUpdateStruct);
+        $object->fillContentTypeUpdateStruct($contentTypeUpdateStruct);
         $this->contentTypeService->updateContentTypeDraft($contentTypeDraft, $contentTypeUpdateStruct);
         $this->contentTypeService->publishContentTypeDraft($contentTypeDraft);
         if ($this->logger) {
@@ -248,7 +231,7 @@ class ContentTypeManager implements LoggerAwareInterface
     private function createFieldDefinition(FieldDefinitionObject $field)
     {
         $definition = $this->contentTypeService->newFieldDefinitionCreateStruct($field->getIdentifier(), $field->type);
-        $field->fillFieldDefinitionUpdateStruct($definition);
+        $field->fillFieldDefinitionCreateStruct($definition);
 
         return $definition;
     }

--- a/src/Transfer/EzPlatform/Worker/Transformer/ArrayToEzPlatformContentTypeObjectTransformer.php
+++ b/src/Transfer/EzPlatform/Worker/Transformer/ArrayToEzPlatformContentTypeObjectTransformer.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Transfer\EzPlatform\Worker\Transformer;
+
+use Transfer\EzPlatform\Data\ContentTypeObject;
+use Transfer\EzPlatform\Data\FieldDefinitionObject;
+use Transfer\EzPlatform\Exception\InvalidDataStructureException;
+use Transfer\Worker\WorkerInterface;
+
+/**
+ * Class ArrayToEzPlatformContentTypeObjectTransformer.
+ */
+class ArrayToEzPlatformContentTypeObjectTransformer implements WorkerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle($array)
+    {
+        if (!is_array($array)) {
+            throw new \InvalidArgumentException(
+                sprintf('Expected argument #1 to be of type array, got %s', gettype($array))
+            );
+        }
+
+        $identifier = key($array);
+        $a = $array[$identifier];
+
+        if (!is_string($identifier)) {
+            throw new \InvalidArgumentException(
+                sprintf('Expected identifier to be of type string, got "%s".', gettype($identifier))
+            );
+        }
+        if (!array_key_exists('fields', $a)) {
+            throw new InvalidDataStructureException(
+                sprintf('Missing key "%s" in identifier "%s".', 'fields', $identifier)
+            );
+        }
+        if (count($a['fields']) == 0) {
+            throw new InvalidDataStructureException(
+                sprintf('Atleast one field must be defined for identifier "%s".', $identifier)
+            );
+        }
+
+        $ct = new ContentTypeObject($identifier);
+
+        if (isset($a['main_language_code'])) {
+            $ct->mainLanguageCode = $a['main_language_code'];
+        }
+
+        if (isset($a['main_group_identifier'])) {
+            $ct->setContentTypeGroups(array($a['main_group_identifier']));
+        }
+
+        if (isset($a['contenttype_groups']) && is_array($a['contenttype_groups'])) {
+            foreach ($a['contenttype_groups'] as $contenttypeGroup) {
+                $ct->addContentTypeGroup($contenttypeGroup);
+            }
+        }
+        if (isset($a['names'])) {
+            $ct->setNames($a['names']);
+        } elseif ($a['name']) {
+            $ct->addName($a['name'], $ct->mainLanguageCode);
+        }
+
+        if (isset($a['descriptions'])) {
+            $ct->setDescriptions($a['descriptions']);
+        } elseif ($a['description']) {
+            $ct->addDescription($a['description'], $ct->mainLanguageCode);
+        }
+
+        if (isset($ct['name_schema'])) {
+            $ct->nameSchema = $a['name_schema'];
+        }
+
+        if (isset($ct['url_alias_schema'])) {
+            $ct->urlAliasSchema = $a['url_alias_schema'];
+        }
+
+        if (isset($ct['container'])) {
+            $ct->isContainer = $a['container'];
+        }
+
+        $positions = array(0);
+        foreach ($a['fields'] as $fieldId => $field) {
+            $fieldDefinition = new FieldDefinitionObject($fieldId);
+
+            if (isset($field['type'])) {
+                $fieldDefinition->type = $field['type'];
+            }
+
+            if (isset($field['names'])) {
+                $fieldDefinition->setNames($field['names']);
+            } elseif (isset($field['name'])) {
+                $fieldDefinition->addName($field['name'], $ct->mainLanguageCode);
+            }
+            if (isset($field['descriptions'])) {
+                $fieldDefinition->setDescriptions($field['descriptions']);
+            } elseif ($field['description']) {
+                $fieldDefinition->addDescription($field['description'], $ct->mainLanguageCode);
+            }
+            if (isset($field['field_group'])) {
+                $fieldDefinition->fieldGroup = $field['field_group'];
+            }
+            $position = isset($field['position']) ? $field['position'] : max($positions) + 10;
+            $positions[] = $fieldDefinition->position = $position;
+
+            if (isset($field['translatable'])) {
+                $fieldDefinition->isTranslatable = $field['translatable'];
+            }
+            if (isset($field['required'])) {
+                $fieldDefinition->isRequired = $field['required'];
+            }
+            if (isset($field['searchable'])) {
+                $fieldDefinition->isSearchable = $field['searchable'];
+            }
+            if (isset($field['info_collector'])) {
+                $fieldDefinition->isInfoCollector = $field['info_collector'];
+            }
+
+            $ct->addFieldDefinition($field);
+        }
+
+        return new ContentTypeObject($ct);
+    }
+}

--- a/tests/Transfer/EzPlatform/Tests/Adapter/EzPlatformAdapterTest.php
+++ b/tests/Transfer/EzPlatform/Tests/Adapter/EzPlatformAdapterTest.php
@@ -9,16 +9,16 @@
 
 namespace Transfer\EzPlatform\Tests\Repository\Manager;
 
+use eZ\Publish\API\Repository\Values\Content\Location;
 use Transfer\Adapter\Transaction\Request;
 use Transfer\Data\TreeObject;
 use Transfer\EzPlatform\Adapter\EzPlatformAdapter;
 use Transfer\EzPlatform\Data\ContentObject;
 use Transfer\EzPlatform\Data\ContentTypeObject;
-use Transfer\EzPlatform\Repository\Manager\ContentManager;
-use Transfer\EzPlatform\Repository\Manager\ContentTypeManager;
+use Transfer\EzPlatform\Data\FieldDefinitionObject;
 use Transfer\EzPlatform\Tests\EzPlatformTestCase;
 
-class EzPlatformAdapterTests extends EzPlatformTestCase
+class EzPlatformAdapterTest extends EzPlatformTestCase
 {
     /**
      * @var EzPlatformAdapter
@@ -28,28 +28,28 @@ class EzPlatformAdapterTests extends EzPlatformTestCase
     public function setUp()
     {
         $this->adapter = new EzPlatformAdapter(array(
-            'repository' => static::$repository
+            'repository' => static::$repository,
         ));
     }
 
     public function testSendContentObject()
     {
         $contentObject = new ContentObject(array(
-            'title' => 'Test'
+            'title' => 'Test',
         ));
         $contentObject->setContentType('_test_article');
         $contentObject->setLanguage('eng-GB');
         $contentObject->setRemoteId('test_1');
 
         $this->adapter->send(new Request(array(
-            $contentObject
+            $contentObject,
         )));
     }
 
     public function testSendTreeObject()
     {
         $contentObject = new ContentObject(array(
-            'title' => 'Test'
+            'title' => 'Test',
         ));
         $contentObject->setContentType('_test_article');
         $contentObject->setLanguage('eng-GB');
@@ -59,7 +59,50 @@ class EzPlatformAdapterTests extends EzPlatformTestCase
         $treeObject->setProperty('location_id', 2);
 
         $this->adapter->send(new Request(array(
-            $treeObject
+            $treeObject,
+        )));
+    }
+
+    public function testSendFullContentTypeObject()
+    {
+        $ct = new ContentTypeObject('_test_article');
+        $ct->mainLanguageCode = 'eng-GB';
+        $ct->addName('Article', 'eng-GB');
+        $ct->setNames(array('eng-GB' => 'Article'));
+        $ct->addDescription('Article description');
+        $ct->isContainer = true;
+        $ct->defaultAlwaysAvailable = true;
+        $ct->addContentTypeGroup('Content');
+        $ct->defaultSortField = Location::SORT_FIELD_PUBLISHED;
+        $ct->defaultSortOrder = Location::SORT_ORDER_DESC;
+        $ct->nameSchema = '<name>';
+        $ct->urlAliasSchema = '<name>';
+
+        $f = new FieldDefinitionObject('name');
+        $f->type = 'ezstring';
+        $f->fieldGroup = 'content';
+        $f->addName('Name', 'eng-GB');
+        $f->setNames(array('eng-GB' => 'Name'));
+        $f->addDescription('Name of the article');
+        $f->isRequired = true;
+        $f->isTranslatable = true;
+        $f->isSearchable = true;
+        $f->isInfoCollector = false;
+        $f->defaultValue = '';
+
+        $ct->addFieldDefinition($f);
+        $this->adapter->send(new Request(array(
+            $ct,
+        )));
+    }
+
+    public function testSendMiniContentTypeObject()
+    {
+        $ct = new ContentTypeObject('_test_frontpage');
+        $f = new FieldDefinitionObject('name');
+        $ct->addFieldDefinition($f);
+        $this->adapter->send(new Request(array(
+            $ct,
         )));
     }
 }

--- a/tests/Transfer/EzPlatform/Tests/EzPlatformTestCase.php
+++ b/tests/Transfer/EzPlatform/Tests/EzPlatformTestCase.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Transfer\EzPlatform\Adapter\EzPlatformAdapter;
 use Transfer\EzPlatform\Data\ContentTypeObject;
+use Transfer\EzPlatform\Data\FieldDefinitionObject;
 use Transfer\EzPlatform\Repository\Manager\ContentTypeManager;
 
 /**
@@ -60,50 +61,36 @@ abstract class EzPlatformTestCase extends KernelTestCase
     {
         $manager = new ContentTypeManager(static::$repository);
 
-        $manager->create(
-            new ContentTypeObject(array(
-                'group_identifier' => 'Content',
-                'identifier' => '_test_article',
-                'main_language_code' => 'eng-GB',
-                'name_schema' => '<name>',
-                'url_alias_schema' => '<name>',
-                'names' => array(
-                    'eng-GB' => 'Article',
-                ),
-                'descriptions' => array(
-                    'eng-GB' => 'An Article',
-                ),
-                'fields' => array(
-                    'title' => array(
-                        'type' => 'ezstring',
-                        'names' => array(
-                            'eng-GB' => 'Name',
-                        ),
-                        'descriptions' => array(
-                            'eng-GB' => 'Name of the frontpage',
-                        ),
-                        'field_group' => 'content',
-                        'position' => 10,
-                        'is_translatable' => true,
-                        'is_required' => true,
-                        'is_searchable' => true,
-                    ),
-                    'description' => array(
-                        'type' => 'ezstring',
-                        'names' => array(
-                            'eng-GB' => 'Description',
-                        ),
-                        'descriptions' => array(
-                            'eng-GB' => 'Description of the frontpage',
-                        ),
-                        'field_group' => 'content',
-                        'position' => 20,
-                        'is_translatable' => true,
-                        'is_required' => false,
-                        'is_searchable' => true,
-                    ),
-                ),
-            ))
-        );
+        $_ct_article = new ContentTypeObject('_test_article');
+        $_ct_article->mainLanguageCode = 'eng-GB';
+        $_ct_article->addContentTypeGroup('Content');
+        $_ct_article->nameSchema = '<title>';
+        $_ct_article->urlAliasSchema = '<title>';
+        $_ct_article->addName('Article');
+        $_ct_article->addDescription('An article');
+
+        $_fd_name = new FieldDefinitionObject('title');
+        $_fd_name->addName('Title');
+        $_fd_name->addDescription('Title of the article');
+        $_fd_name->fieldGroup = 'content';
+        $_fd_name->position = 10;
+        $_fd_name->isRequired = true;
+        $_fd_name->isTranslatable = true;
+        $_fd_name->isSearchable= true;
+        $_fd_name->isInfoCollector = false;
+        $_ct_article->addFieldDefinition($_fd_name);
+
+        $_fd_desc = new FieldDefinitionObject('description');
+        $_fd_desc->addName('Description');
+        $_fd_desc->addDescription('Description of the article');
+        $_fd_desc->fieldGroup = 'content';
+        $_fd_desc->position = 20;
+        $_fd_desc->isRequired = false;
+        $_fd_desc->isTranslatable = true;
+        $_fd_desc->isSearchable= true;
+        $_fd_desc->isInfoCollector = false;
+        $_ct_article->addFieldDefinition($_fd_desc);
+
+        $manager->createOrUpdate($_ct_article);
     }
 }

--- a/tests/Transfer/EzPlatform/Tests/Repository/Manager/ContentManagerTest.php
+++ b/tests/Transfer/EzPlatform/Tests/Repository/Manager/ContentManagerTest.php
@@ -10,9 +10,7 @@
 namespace Transfer\EzPlatform\Tests\Repository\Manager;
 
 use Transfer\EzPlatform\Data\ContentObject;
-use Transfer\EzPlatform\Data\ContentTypeObject;
 use Transfer\EzPlatform\Repository\Manager\ContentManager;
-use Transfer\EzPlatform\Repository\Manager\ContentTypeManager;
 use Transfer\EzPlatform\Tests\EzPlatformTestCase;
 
 /**
@@ -24,19 +22,22 @@ class ContentManagerTest extends EzPlatformTestCase
     {
         $manager = new ContentManager(static::$repository);
 
-        $contentObject = new ContentObject(array(
-            'title' => 'Test title',
-            'description' => 'Test description',
-        ));
-        $contentObject->setContentType('_test_article');
-        $contentObject->setLanguage('eng-GB');
-        $contentObject->setRemoteId('_test_1');
 
-        $manager->create($contentObject);
+            $contentObject = new ContentObject(array(
+                'name' => 'Test title',
+                'title' => 'Test title',
+                'description' => 'Test description',
+            ));
+            $contentObject->setContentType('_test_article');
+            $contentObject->setLanguage('eng-GB');
+            $contentObject->setRemoteId('_test_1');
 
-        $createdContentObject = $manager->findByRemoteId('_test_1');
+            $manager->create($contentObject);
 
-        $this->assertEquals('Test title', (string) $createdContentObject->data['title']['eng-GB']);
-        $this->assertEquals('Test description', (string) $createdContentObject->data['description']['eng-GB']);
+            $createdContentObject = $manager->findByRemoteId('_test_1');
+
+            $this->assertEquals('Test title', (string) $createdContentObject->data['title']['eng-GB']);
+            $this->assertEquals('Test description', (string) $createdContentObject->data['description']['eng-GB']);
+
     }
 }

--- a/tests/Transfer/EzPlatform/Tests/Repository/Manager/ContentTypeManagerTest.php
+++ b/tests/Transfer/EzPlatform/Tests/Repository/Manager/ContentTypeManagerTest.php
@@ -10,6 +10,7 @@
 namespace Transfer\EzPlatform\Tests\Repository\Manager;
 
 use Transfer\EzPlatform\Data\ContentTypeObject;
+use Transfer\EzPlatform\Data\FieldDefinitionObject;
 use Transfer\EzPlatform\Repository\Manager\ContentTypeManager;
 use Transfer\EzPlatform\Tests\EzPlatformTestCase;
 
@@ -36,15 +37,48 @@ class ContentTypeManagerTest extends EzPlatformTestCase
         $this->assertEquals('<name>', $contentType->urlAliasSchema);
         $this->assertEquals('<name>', $contentType->nameSchema);
         $this->assertEquals('eng-GB', $contentType->mainLanguageCode);
+        $this->assertTrue($contentType->isContainer);
         $contentFieldDefinition = $contentType->fieldDefinitions[0];
         $this->assertInstanceOf('eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition', $contentFieldDefinition);
-        $this->assertEquals('title', $contentFieldDefinition->identifier);
+        $this->assertEquals('name', $contentFieldDefinition->identifier);
         $this->assertEquals('Name', $contentFieldDefinition->getName('eng-GB'));
         $this->assertEquals('Name of the frontpage', $contentFieldDefinition->getDescription('eng-GB'));
         $this->assertEquals('ezstring', $contentFieldDefinition->fieldTypeIdentifier);
         $this->assertTrue($contentFieldDefinition->isTranslatable);
         $this->assertTrue($contentFieldDefinition->isRequired);
         $this->assertTrue($contentFieldDefinition->isSearchable);
+        $this->assertFalse($contentFieldDefinition->isInfoCollector);
+
+        $this->update($manager);
+
+        $contentType = $manager->findByIdentifier('frontpage');
+        $this->assertEquals('Updated frontpage', $contentType->getName('eng-GB'));
+        $this->assertEquals('Updated frontpage description', $contentType->getDescription('eng-GB'));
+        $this->assertFalse($contentType->isContainer);
+
+        $this->assertCount(3, $contentType->fieldDefinitions);
+        $contentFieldDefinition = $contentType->fieldDefinitions[1];
+        $this->assertInstanceOf('eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition', $contentFieldDefinition);
+        $this->assertEquals('name', $contentFieldDefinition->identifier);
+        $this->assertEquals('Name', $contentFieldDefinition->getName('eng-GB'));
+        $this->assertEquals('Updated name description', $contentFieldDefinition->getDescription('eng-GB'));
+        $this->assertEquals('ezstring', $contentFieldDefinition->fieldTypeIdentifier);
+        $this->assertFalse($contentFieldDefinition->isTranslatable);
+        $this->assertFalse($contentFieldDefinition->isRequired);
+        $this->assertFalse($contentFieldDefinition->isSearchable);
+        $this->assertFalse($contentFieldDefinition->isInfoCollector);
+
+        $contentFieldDefinition = $contentType->fieldDefinitions[0];
+        $this->assertInstanceOf('eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition', $contentFieldDefinition);
+        $this->assertEquals('short_description', $contentFieldDefinition->identifier);
+        $this->assertEquals('Short description', $contentFieldDefinition->getName('eng-GB'));
+        $this->assertEquals('', $contentFieldDefinition->getDescription('eng-GB'));
+        $this->assertEquals('ezstring', $contentFieldDefinition->fieldTypeIdentifier);
+        $this->assertTrue($contentFieldDefinition->isTranslatable);
+        $this->assertFalse($contentFieldDefinition->isRequired);
+        $this->assertTrue($contentFieldDefinition->isSearchable);
+        $this->assertFalse($contentFieldDefinition->isInfoCollector);
+
     }
 
     public function testUpdate()
@@ -62,135 +96,20 @@ class ContentTypeManagerTest extends EzPlatformTestCase
 
     protected function create(ContentTypeManager $manager)
     {
-        return $manager->create(
-            new ContentTypeObject(array(
-                'group_identifier' => 'Content',
-                'identifier' => 'frontpage',
-                'main_language_code' => 'eng-GB',
-                'name_schema' => '<name>',
-                'url_alias_schema' => '<name>',
-                'names' => array(
-                    'eng-GB' => 'Frontpage',
-                ),
-                'descriptions' => array(
-                    'eng-GB' => 'A frontpage',
-                ),
-                'fields' => array(
-                    'title' => array(
-                        'type' => 'ezstring',
-                        'names' => array(
-                            'eng-GB' => 'Name',
-                        ),
-                        'descriptions' => array(
-                            'eng-GB' => 'Name of the frontpage',
-                        ),
-                        'field_group' => 'content',
-                        'position' => 10,
-                        'is_translatable' => true,
-                        'is_required' => true,
-                        'is_searchable' => true,
-                    ),
-                ),
-            ))
-        );
+        $ct = $this->getFrontpageContentTypeObject();
+        return $manager->create($ct);
     }
 
     protected function createOrUpdate(ContentTypeManager $manager)
     {
-        return $manager->createOrUpdate(
-            new ContentTypeObject(array(
-                'group_identifier' => 'Content',
-                'identifier' => 'frontpage',
-                'main_language_code' => 'eng-GB',
-                'name_schema' => '<name>',
-                'url_alias_schema' => '<name>',
-                'names' => array(
-                    'eng-GB' => 'Frontpage',
-                ),
-                'descriptions' => array(
-                    'eng-GB' => 'A frontpage',
-                ),
-                'fields' => array(
-                    'title' => array(
-                        'type' => 'ezstring',
-                        'names' => array(
-                            'eng-GB' => 'Name',
-                        ),
-                        'descriptions' => array(
-                            'eng-GB' => 'Name of the frontpage',
-                        ),
-                        'field_group' => 'content',
-                        'position' => 10,
-                        'is_translatable' => true,
-                        'is_required' => true,
-                        'is_searchable' => true,
-                    ),
-                    'description' => array(
-                        'type' => 'ezstring',
-                        'names' => array(
-                            'eng-GB' => 'Description',
-                        ),
-                        'descriptions' => array(
-                            'eng-GB' => 'Description of the frontpage',
-                        ),
-                        'field_group' => 'content',
-                        'position' => 20,
-                        'is_translatable' => true,
-                        'is_required' => false,
-                        'is_searchable' => true,
-                    ),
-                ),
-            ))
-        );
+        $ct = $this->getFrontpageContentTypeObject();
+        return $manager->createOrUpdate($ct);
     }
 
     protected function update(ContentTypeManager $manager)
     {
-        return $manager->update(
-            new ContentTypeObject(array(
-                'group_identifier' => 'Content',
-                'identifier' => 'frontpage',
-                'main_language_code' => 'eng-GB',
-                'name_schema' => '<name>',
-                'url_alias_schema' => '<name>',
-                'names' => array(
-                    'eng-GB' => 'Frontpage',
-                ),
-                'descriptions' => array(
-                    'eng-GB' => 'A frontpage',
-                ),
-                'fields' => array(
-                    'title' => array(
-                        'type' => 'ezstring',
-                        'names' => array(
-                            'eng-GB' => 'Name',
-                        ),
-                        'descriptions' => array(
-                            'eng-GB' => 'Name of the frontpage',
-                        ),
-                        'field_group' => 'content',
-                        'position' => 10,
-                        'is_translatable' => true,
-                        'is_required' => true,
-                        'is_searchable' => true,
-                    ),
-                    'description' => array(
-                        'type' => 'ezstring',
-                        'names' => array(
-                            'eng-GB' => 'Description',
-                        ),
-                        'descriptions' => array(
-                            'eng-GB' => 'Description of the frontpage',
-                        ),
-                        'field_group' => 'content',
-                        'position' => 20,
-                        'is_translatable' => true,
-                        'is_required' => false,
-                        'is_searchable' => true,
-                    ),
-                ),
-            ))
-        );
+        $ct = $this->getUpdatedFrontpageContentTypeObject();
+        return $manager->update($ct);
     }
 
     protected function find(ContentTypeManager $manager)
@@ -200,10 +119,79 @@ class ContentTypeManagerTest extends EzPlatformTestCase
 
     protected function delete(ContentTypeManager $manager)
     {
-        $manager->remove(
-            new ContentTypeObject(array(
-                'identifier' => 'frontpage',
-            ))
+        $manager->removeByIdentifier(
+            $this->getFrontpageContentTypeObject()->getIdentifier()
         );
     }
+
+    /**
+     * @return ContentTypeObject
+     */
+    protected function getFrontpageContentTypeObject()
+    {
+        $ct = new ContentTypeObject('frontpage');
+        $ct->mainLanguageCode = 'eng-GB';
+        $ct->addContentTypeGroup('Content');
+        $ct->nameSchema = '<name>';
+        $ct->urlAliasSchema = '<name>';
+        $ct->isContainer = true;
+        $ct->setNames(array('eng-GB' => 'Frontpage'));
+        $ct->setDescriptions(array('eng-GB' => 'A frontpage'));
+
+        $field = new FieldDefinitionObject('name');
+        $field->type = 'ezstring';
+        $field->setNames(array('eng-GB' => 'Name'));
+        $field->setDescriptions(array('eng-GB' => 'Name of the frontpage'));
+        $field->fieldGroup = 'content';
+        $field->position = 10;
+        $field->isTranslatable = true;
+        $field->isRequired = true;
+        $field->isSearchable = true;
+        $field->isInfoCollector = false;
+        $ct->addFieldDefinition($field);
+
+        $field = new FieldDefinitionObject('description');
+        $field->type = 'ezstring';
+        $field->setNames(array('eng-GB' => 'Description'));
+        $field->setDescriptions(array('eng-GB' => 'Description of the frontpage'));
+        $field->fieldGroup = 'content';
+        $field->position = 20;
+        $field->isTranslatable = true;
+        $field->isRequired = false;
+        $field->isSearchable = true;
+        $field->isInfoCollector = false;
+        $ct->addFieldDefinition($field);
+
+        return $ct;
+    }
+
+    /**
+     * @return ContentTypeObject
+     */
+    protected function getUpdatedFrontpageContentTypeObject()
+    {
+        $ct = new ContentTypeObject('frontpage');
+        $ct->isContainer = false;
+        $ct->setNames(array('eng-GB' => 'Updated frontpage'));
+        $ct->setDescriptions(array('eng-GB' => 'Updated frontpage description'));
+
+        $field = new FieldDefinitionObject('name');
+        $field->type = 'ezstring';
+        $field->setNames(array('eng-GB' => 'Name'));
+        $field->setDescriptions(array('eng-GB' => 'Updated name description'));
+        $field->fieldGroup = 'content';
+        $field->position = 10;
+        $field->isTranslatable = false;
+        $field->isRequired = false;
+        $field->isSearchable = false;
+        $field->isInfoCollector = false;
+        $ct->addFieldDefinition($field);
+
+        $field = new FieldDefinitionObject('short_description');
+        $field->setNames(array('eng-GB' => 'Short description'));
+        $ct->addFieldDefinition($field);
+
+        return $ct;
+    }
+
 }


### PR DESCRIPTION
Adds a more strict, but accurate way to build up creations. Only identifiers are required. No need for the array-buildup to be so loose, when the accepted/possible data is so strict.
