### PR TITLE
Allow fields that only has an identifier

### DIFF
--- a/src/Transfer/EzPlatform/Worker/Transformer/ArrayToEzPlatformContentTypeObjectTransformer.php
+++ b/src/Transfer/EzPlatform/Worker/Transformer/ArrayToEzPlatformContentTypeObjectTransformer.php
@@ -112,14 +112,18 @@ class ArrayToEzPlatformContentTypeObjectTransformer implements WorkerInterface
     }
 
     /**
-     * @param $fieldIdentifier
-     * @param $fieldDefinitionData
+     * @param string     $fieldIdentifier
+     * @param array|null $fieldDefinitionData
      *
      * @return FieldDefinitionObject
      */
-    private function getFieldDefinitionFromData($fieldIdentifier, $fieldDefinitionData)
+    private function getFieldDefinitionFromData($fieldIdentifier, $fieldDefinitionData = null)
     {
         $fd = new FieldDefinitionObject($fieldIdentifier);
+        if (!is_array($fieldDefinitionData) || empty($fieldDefinitionData)) {
+            return $fd;
+        }
+
         foreach ($fieldDefinitionData as $key => $value) {
             switch ($key) {
                 case 'type':

--- a/tests/Transfer/EzPlatform/Tests/Worker/Transformer/ArrayToEzPlatformContentTypeObjectTest.php
+++ b/tests/Transfer/EzPlatform/Tests/Worker/Transformer/ArrayToEzPlatformContentTypeObjectTest.php
@@ -5,6 +5,19 @@ use Transfer\EzPlatform\Worker\Transformer\ArrayToEzPlatformContentTypeObjectTra
 
 class ArrayToEzPlatformContentTypeObjectTest extends \PHPUnit_Framework_TestCase
 {
+
+    public function testEmptyField()
+    {
+        $array = array('article' => array(
+            'fields' => array(
+                'title' => '',
+            ),
+        ));
+
+        $transformer = new ArrayToEzPlatformContentTypeObjectTransformer();
+        $transformer->handle($array);
+    }
+
     public function testEmptyArray()
     {
         $transformer = new ArrayToEzPlatformContentTypeObjectTransformer();


### PR DESCRIPTION
transfer-framework/examples#2 fails because fields which only has an identifier, and no further data isn't taken care of.
