### PR TITLE
Drop hhvm from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ matrix:
         - php: 5.5
         - php: 5.6
         - php: 7.0
-        - php: hhvm
-    allow_failures:
-        - php: hhvm
     fast_finish: true
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "~5.5|~7.0",
         "transfer/transfer": "~1.0.0",
         "ezsystems/ezpublish-kernel": "~6.3",
-        "symfony/config": "~2.7|~3.0.0"
+        "symfony/config": "~2.7|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7"

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "type": "transfer-extension",
     "description": "eZ Platform extension for Transfer",
     "keywords": ["transfer", "ezpublish", "ezplatform"],
-    "minimun-stability": "stable",
     "license": "MIT",
     "author": [
         {
@@ -19,7 +18,7 @@
         "php": "~5.5|~7.0",
         "transfer/transfer": "~1.0.0",
         "ezsystems/ezpublish-kernel": "~6.3",
-        "symfony/config": "~2.7.7"
+        "symfony/config": "~2.7|~3.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7"


### PR DESCRIPTION
ezsystems/ezpublish-kernel does not run Travis for hhvm, so no real reason for us to support it either.

| Q             | A
| ------------- | ---
| Branch?       | 1.0
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
