### PR TITLE
Too strict symfony/config requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "~5.5|~7.0",
         "transfer/transfer": "~1.0.0",
         "ezsystems/ezpublish-kernel": "~6.3",
-        "symfony/config": "~2.7|~3.0"
+        "symfony/config": "~2.7|~2.8|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7"


### PR DESCRIPTION
Since 2.7 and 3.0 of symfony/config is already supported, I'm assuming 2.8 won't be a problem to support as well.

| Q             | A
| ------------- | ---
| Branch?       | 1.0
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ?
| Fixed tickets | none
| License       | MIT
| Doc PR        | none
