### PR TITLE
Less strict eZ Publish kernel requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "~5.5|~7.0",
         "transfer/transfer": "~1.0.0",
-        "ezsystems/ezpublish-kernel": "~6.3",
+        "ezsystems/ezpublish-kernel": "~5.4|~6.3",
         "symfony/config": "~2.7|~2.8|~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Based on the fact that we are already using this library in an eZ Publish 5.4 installation.